### PR TITLE
Trim "tags/" from git describe output

### DIFF
--- a/git.go
+++ b/git.go
@@ -151,6 +151,7 @@ func Describe(gitDir, ref string) (desc string, err error) {
 
 	desc = strings.TrimSpace(string(stdout))
 	desc = strings.TrimPrefix(desc, "heads/")
+	desc = strings.TrimPrefix(desc, "tags/")
 	return desc, nil
 }
 


### PR DESCRIPTION
It's possible for the output of the git describe command used here to 
start with a `tags/` prefix, not a `heads/` one (e.g. if current commit 
is tagged), therefore remove this in a similar way.